### PR TITLE
Add sample log parser tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,5 +30,7 @@ token.txt
 env/
 .env
 input/
+!tests/input/
+!tests/input/logs.txt
 output/
 db.tsv

--- a/tests/input/logs.txt
+++ b/tests/input/logs.txt
@@ -1,0 +1,12 @@
+    1/1-1/7
+        1b. What time start winding down? 10pm 10pm 10pm 10pm 10pm 10pm 10pm
+        1.2b. What time did you get into bed & commit to sleep? 11pm 11pm 11pm 11pm 11pm 11pm 11pm
+        6. What time did you wake up? 7am 7am 7am 7am 7am 7am 7am
+        7. What time did you get out of bed? 7:15am 7:15am 7:15am 7:15am 7:15am 7:15am 7:15am
+        14. If alcohol, how many standard drinks? 0 1 0 1 0 1 0
+    1/8-1/14
+        1b. What time start winding down? 21:30 21:30 21:30 21:30 21:30 21:30 21:30
+        1.2b. What time did you get into bed & commit to sleep? 22:30 22:30 22:30 22:30 22:30 22:30 22:30
+        6. What time did you wake up? 06:30 06:30 06:30 06:30 06:30 06:30 06:30
+        7. What time did you get out of bed? 06:45 06:45 06:45 06:45 06:45 06:45 06:45
+        14. If alcohol, how many standard drinks? 1 1 1 1 1 1 1

--- a/tests/test_log_parser.py
+++ b/tests/test_log_parser.py
@@ -1,0 +1,33 @@
+import pandas as pd
+import pytest
+
+from sleep_analysis.log_parser import parse_log, compute_weekly_stats, compute_overall_stats
+
+
+@pytest.fixture
+
+def sample_log_path():
+    return 'tests/input/logs.txt'
+
+
+def test_parse_log(sample_log_path):
+    df = parse_log(sample_log_path)
+    assert len(df) == 14
+    assert set(df['week_label']) == {'0101-0107', '0108-0114'}
+    assert df['wind_down_start_time'].notna().all()
+
+
+def test_compute_weekly_stats(sample_log_path):
+    df = parse_log(sample_log_path)
+    weekly = compute_weekly_stats(df)
+    assert set(weekly.keys()) == {'0101-0107', '0108-0114'}
+    assert weekly['0101-0107']['total_drinks'].iloc[0] == 3
+    assert weekly['0108-0114']['total_drinks'].iloc[0] == 7
+
+
+def test_compute_overall_stats(sample_log_path):
+    df = parse_log(sample_log_path)
+    weekly = compute_weekly_stats(df)
+    overall = compute_overall_stats(weekly)
+    assert len(overall) == 1
+    assert overall['total_drinks'].iloc[0] == pytest.approx((3 + 7) / 2)


### PR DESCRIPTION
## Summary
- add fixture log data in `tests/input/logs.txt`
- create `tests/test_log_parser.py` to cover main parsing functions
- update `.gitignore` to allow checked-in input file

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685dfd0653b8832ca8f60c3cbb538be2