### PR TITLE
Fix weekly stats with missing week labels

### DIFF
--- a/sleep_analysis/log_parser.py
+++ b/sleep_analysis/log_parser.py
@@ -184,6 +184,8 @@ def parse_log(path: str) -> pd.DataFrame:
 
 def compute_weekly_stats(df: pd.DataFrame) -> Dict[str, pd.DataFrame]:
     weekly_dfs = {}
+    if df.empty or 'week_label' not in df.columns:
+        return weekly_dfs
     for label, wk_df in df.groupby('week_label'):
         stats: Dict[str, List] = {}
         stats['total_drinks'] = [wk_df.get('alcohol_drinks', pd.Series(dtype=float)).fillna(0).sum()]

--- a/tests/test_log_parser.py
+++ b/tests/test_log_parser.py
@@ -189,3 +189,15 @@ def test_compute_overall_stats(sample_log_path):
     overall = compute_overall_stats(weekly)
     assert len(overall) == 1
     assert overall['total_drinks'].iloc[0] == pytest.approx((3 + 7) / 2)
+
+
+def test_compute_weekly_stats_handles_missing_week_label():
+    df = pd.DataFrame({'foo': [1, 2]})
+    weekly = compute_weekly_stats(df)
+    assert weekly == {}
+
+
+def test_compute_weekly_stats_empty_dataframe():
+    df = pd.DataFrame({})
+    weekly = compute_weekly_stats(df)
+    assert weekly == {}


### PR DESCRIPTION
## Summary
- avoid crash when `compute_weekly_stats` receives a DataFrame lacking `week_label`
- add tests for DataFrames without `week_label` or completely empty

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e032d4aac832cbe38a878fc9148f3