### PR TITLE
Improve time stats formatting and add summary metrics

### DIFF
--- a/tests/test_log_parser.py
+++ b/tests/test_log_parser.py
@@ -194,7 +194,7 @@ def test_compute_overall_stats(sample_log_path):
     weekly = compute_weekly_stats(df)
     overall = compute_overall_stats(weekly)
     assert len(overall) == 1
-    assert overall['total_drinks'].iloc[0] == pytest.approx((3 + 7) / 2)
+    assert overall['total_drinks_mean'].iloc[0] == pytest.approx((3 + 7) / 2)
 
 
 def test_compute_weekly_stats_handles_missing_week_label():


### PR DESCRIPTION
## Summary
- move `avg` suffixes to end of stat column names
- format average time columns with am/pm
- compute overall mean and std for each stat
- adjust test for new column name

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cb847cb1c832cbf84262dfcab8ab8