### PR TITLE
Add median stats and per-week std

### DIFF
--- a/tests/test_log_parser.py
+++ b/tests/test_log_parser.py
@@ -194,7 +194,8 @@ def test_compute_overall_stats(sample_log_path):
     weekly = compute_weekly_stats(df)
     overall = compute_overall_stats(weekly)
     assert len(overall) == 1
-    assert overall['total_drinks_mean'].iloc[0] == pytest.approx((3 + 7) / 2)
+    assert 'total_drinks_mean' not in overall.columns
+    assert overall['total_drinks_median'].iloc[0] == pytest.approx(5)
 
 
 def test_compute_weekly_stats_handles_missing_week_label():


### PR DESCRIPTION
## Summary
- calculate median and std in `compute_weekly_stats`
- drop redundant mean columns in overall stats and compute medians
- adjust unit tests for new stats behaviour

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686f5b5de4bc832ca036b9f365ebdfc9