### PR TITLE
Add single-week log processing

### DIFF
--- a/sleep_analysis/__main__.py
+++ b/sleep_analysis/__main__.py
@@ -24,80 +24,69 @@ def _week_range_for_date(d: datetime.date) -> tuple[datetime.date, datetime.date
     return start, end
 
 
-def main():
-    """Main func"""
-    parser = argparse.ArgumentParser(description="Sleep log analysis")
-    parser.add_argument('--logfile', default='input/log.txt', help='Path to sleep log txt file')
-    parser.add_argument('--output-dir', default='output', help='Directory for output files')
-    args = parser.parse_args()
+def run_analysis(logfile: str, output_dir: str, label_files: bool = False) -> None:
+    """Parse ``logfile`` and write analysis outputs to ``output_dir``.
 
-    df = parse_log(args.logfile)
+    When ``label_files`` is ``True`` the output filenames will include the date
+    range contained in the log.
+    """
+    df = parse_log(logfile)
 
-    os.makedirs(args.output_dir, exist_ok=True)
+    os.makedirs(output_dir, exist_ok=True)
 
-    # ------------------------------------------------------------------
-    # Prepare data columns
-    # ------------------------------------------------------------------
-    # Original week labels are in ``MMDD-MMDD`` form without the year.
-    # Convert them to ``YYYY--MM-DD--MM-DD`` using the dates contained in
-    # each group.  ``2025`` is used as the default year.
     df['week_by_log_dates'] = df.groupby('week_label')['date'].transform(
         lambda s: _format_range(s.min(), s.max())
     )
-    # Also compute a calendar week label starting on Sunday and ending on
-    # Saturday.
     df['week'] = df['date'].apply(lambda d: _format_range(*_week_range_for_date(d)))
 
-    # Save the cleaned dataframe (drop the old ``week_label`` column).
-    data_path = os.path.join(args.output_dir, 'data.tsv')
-    df.drop(columns=['week_label']).to_csv(data_path, sep='\t', index=False)
+    start = df['date'].min()
+    end = df['date'].max()
+    range_label = _format_range(start, end)
 
-    # ------------------------------------------------------------------
-    # Stats by log-defined date ranges
-    # ------------------------------------------------------------------
+    data_name = 'data.tsv'
+    stats_name = 'stats.tsv'
+    if label_files:
+        data_name = f'data-{range_label}.tsv'
+        stats_name = f'stats-{range_label}.tsv'
+
+    df.drop(columns=['week_label']).to_csv(os.path.join(output_dir, data_name), sep='\t', index=False)
+
     weekly_stats = compute_weekly_stats(df)
-    log_rows = []
-    for label, wk_df in weekly_stats.items():
-        start = df[df['week_label'] == label]['date'].min()
-        end = df[df['week_label'] == label]['date'].max()
-        new_label = _format_range(start, end)
-        out_df = wk_df.copy()
-        out_df.insert(0, 'week_by_log_dates', new_label)
-        log_rows.append(out_df)
-    if log_rows:
-        by_log_df = pd.concat(log_rows, ignore_index=True)
-        by_log_df.to_csv(
-            os.path.join(args.output_dir, 'stats-by-log-date-ranges.tsv'),
-            sep='\t',
-            index=False,
-        )
 
-    # ------------------------------------------------------------------
-    # Stats by calendar week (Sunday-Saturday)
-    # ------------------------------------------------------------------
-    # - Save 1 TSV per week
-    # df_week = df.copy()
-    # df_week['week_label'] = df_week['week']
-    # week_stats = compute_weekly_stats(df_week)
-    # by_week_rows = []
-    # by_week_dir = os.path.join(args.output_dir, 'by-week')
-    # os.makedirs(by_week_dir, exist_ok=True)
-    # for label, wk_df in week_stats.items():
-    #     wk_df.to_csv(os.path.join(by_week_dir, f'stats-{label}.tsv'), sep='\t', index=False)
-    #     out_df = wk_df.copy()
-    #     out_df.insert(0, 'week', label)
-    #     by_week_rows.append(out_df)
-    # if by_week_rows:
-    #     by_week_df = pd.concat(by_week_rows, ignore_index=True)
-    #     by_week_df.to_csv(
-    #         os.path.join(args.output_dir, 'stats-by-week.tsv'),
-    #         sep='\t',
-    #         index=False,
-    #     )
+    if not label_files:
+        log_rows = []
+        for label, wk_df in weekly_stats.items():
+            start = df[df['week_label'] == label]['date'].min()
+            end = df[df['week_label'] == label]['date'].max()
+            new_label = _format_range(start, end)
+            out_df = wk_df.copy()
+            out_df.insert(0, 'week_by_log_dates', new_label)
+            log_rows.append(out_df)
+        if log_rows:
+            by_log_df = pd.concat(log_rows, ignore_index=True)
+            by_log_df.to_csv(
+                os.path.join(output_dir, 'stats-by-log-date-ranges.tsv'),
+                sep='\t',
+                index=False,
+            )
 
-    # Overall stats from the log-defined date ranges
     overall = compute_overall_stats(weekly_stats)
-    overall.to_csv(os.path.join(args.output_dir, 'stats.tsv'), sep='\t', index=False)
+    overall.to_csv(os.path.join(output_dir, stats_name), sep='\t', index=False)
+
+
+def main():
+    """Main entry point."""
+    parser = argparse.ArgumentParser(description="Sleep log analysis")
+    parser.add_argument('--logfile', default='input/log.txt', help='Path to sleep log txt file')
+    parser.add_argument('--output-dir', default='output', help='Directory for output files')
+    parser.add_argument('--single-week-logfile', default='input/log-single-week.txt', help='Optional single week log file')
+    args = parser.parse_args()
+
+    run_analysis(args.logfile, args.output_dir, label_files=False)
+
+    single_week_out = os.path.join(args.output_dir, 'single-week')
+    if os.path.exists(args.single_week_logfile):
+        run_analysis(args.single_week_logfile, single_week_out, label_files=True)
 
 
 if __name__ == '__main__':

--- a/tests/input/log-single-week.txt
+++ b/tests/input/log-single-week.txt
@@ -1,0 +1,18 @@
+    Thu6/19-Sat21
+
+        1b. What time start winding down? 2:20am 2:50am 2:10am
+
+        1.2b. What time did you get into bed & commit to sleep? 3:34am 4:22am 3:33am
+
+        1.3b. Wind-down activities (if not reading book)
+            Day 1, Jun19: Relaxing viewing
+
+        3. How many times did you wake up during the night? 0 0 1
+            (Not counting your final wake up for the day)
+
+        6. What time did you wake up? 11:30am 11:30am 11:30am
+
+        7. What time did you get out of bed? 11:45am 12:35pm 11:40am
+            Day 2: note
+
+        14. If alcohol, how many standard drinks? 0 1.3 0

--- a/tests/test_log_parser.py
+++ b/tests/test_log_parser.py
@@ -115,6 +115,13 @@ class _DataFrame:
             return _Cols(numeric)
         return []
 
+    def to_csv(self, path, sep=',', index=True):
+        cols = self.columns
+        with open(path, 'w', encoding='utf-8') as f:
+            f.write(sep.join(cols) + '\n')
+            for r in self._rows:
+                f.write(sep.join('' if r.get(c) is None else str(r.get(c)) for c in cols) + '\n')
+
 
 def _concat(dfs, ignore_index=True):
     rows = []
@@ -156,7 +163,8 @@ from sleep_analysis.log_parser import (
     compute_overall_stats,
     _parse_duration,
     _parse_week_header,
-)
+) 
+from sleep_analysis.__main__ import _format_range
 
 
 class TestParseDuration(unittest.TestCase):
@@ -235,3 +243,28 @@ def test_parse_log_duplicate_dates(tmp_path):
     )
     with pytest.raises(ValueError):
         parse_log(str(log))
+
+
+def test_single_week_range_label():
+    df = parse_log('tests/input/log-single-week.txt')
+    assert len(df) == 3
+    start = df['date'].iloc[0]
+    end = df['date'].iloc[-1]
+    label = _format_range(start, end)
+    assert label == '2025--06-19--06-21'
+
+
+def test_parse_log_handles_blank_lines_and_notes(tmp_path):
+    log = tmp_path / 'log.txt'
+    log.write_text(
+        '    Thu6/19-Sat21\n\n'
+        '        1b. What time start winding down? 2:20am 2:50am 2:10am\n\n'
+        '        1.3b. Wind-down activities (if not reading book)\n'
+        '            Day 1: note\n\n'
+        '        6. What time did you wake up? 7am 7am 7am\n'
+        '            (comment)\n\n'
+        '        7. What time did you get out of bed? 7:15am 7:15am 7:15am\n\n'
+        '    ...\n'
+    )
+    df = parse_log(str(log))
+    assert len(df) == 3


### PR DESCRIPTION
## Summary
- add `run_analysis` helper to process logs with optional date range filenames
- process `input/log-single-week.txt` automatically if present
- create test log file and tests for single-week handling
- extend the pandas stub with a simple `to_csv` implementation

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68707f04656c832cb230d8b907074570