### PR TITLE
Improve week header detection

### DIFF
--- a/sleep_analysis/log_parser.py
+++ b/sleep_analysis/log_parser.py
@@ -22,6 +22,15 @@ EXPECTED_TIMES = {
 
 _TIME_RE = re.compile(r'^(\d{1,2})(?::(\d{2}))?(am|pm)?$', re.IGNORECASE)
 
+# Matches week header lines such as ``"Fri4/25-Wed4/30"`` or ``"Thu6/19-Wed25"``
+# where the day-of-week prefix is optional for both the start and end dates. The
+# month/day pairs may also omit the month on the end date in which case the
+# start month is assumed.
+_WEEK_HEADER_RE = re.compile(
+    r'^(?:[A-Za-z]{3})?\d{1,2}/\d{1,2}-'
+    r'(?:[A-Za-z]{3})?(?:\d{1,2}/)?\d{1,2}$'
+)
+
 
 def _parse_time(value: str) -> datetime.time | None:
     if value in {'.', '', None}:
@@ -178,7 +187,8 @@ def parse_log(path: str) -> pd.DataFrame:
         expanded = line.replace('\t', '    ')
         indent = len(expanded) - len(expanded.lstrip(' '))
         stripped = line.strip()
-        if indent == 4:  # week header
+
+        if _WEEK_HEADER_RE.match(stripped):
             if week_label and week_days:
                 # flush previous week
                 for i, day in enumerate(week_days):
@@ -194,7 +204,7 @@ def parse_log(path: str) -> pd.DataFrame:
             else:
                 week_label = None
                 week_days = []
-        elif indent == 8 and week_label:
+        elif indent >= 4 and week_label:
             if '?' in stripped:
                 q_part, values_part = stripped.split('?', 1)
                 question = (q_part + '?').strip()

--- a/tests/input/long-single-week.txt
+++ b/tests/input/long-single-week.txt
@@ -1,0 +1,3 @@
+Thu6/19-Wed21
+    1b. What time start winding down? 2:20am 2:50am 2:10am
+    6. What time did you wake up? 11:30am 11:40am 11:50am

--- a/tests/test_log_parser.py
+++ b/tests/test_log_parser.py
@@ -269,3 +269,10 @@ def test_parse_log_handles_blank_lines_and_notes(tmp_path):
     )
     df = parse_log(str(log))
     assert len(df) == 3
+
+
+def test_parse_log_week_header_without_indent():
+    df = parse_log('tests/input/long-single-week.txt')
+    assert len(df) == 3
+    assert set(df['week_label']) == {'0619-0621'}
+    assert df['wind_down_start_time'][0] is not None


### PR DESCRIPTION
## Summary
- support week headers without indentation using `_WEEK_HEADER_RE`
- handle question blocks if indented at least 4 spaces
- add regression test for no-indent week header

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687086fcf6b4832c89371cc2b2290a91