### PR TITLE
Add CSV export for log weeks

### DIFF
--- a/sleep_analysis/__main__.py
+++ b/sleep_analysis/__main__.py
@@ -7,6 +7,7 @@ import pandas as pd
 
 from sleep_analysis.log_parser import (
     parse_log,
+    export_single_weeks_csv,
     compute_weekly_stats,
     compute_overall_stats,
 )
@@ -55,6 +56,7 @@ def run_analysis(logfile: str, output_dir: str, label_files: bool = False) -> No
     df.drop(columns=['week_label']).to_csv(os.path.join(output_dir, data_name), sep='\t', index=False)
 
     weekly_stats = compute_weekly_stats(df)
+    export_single_weeks_csv(logfile, os.path.join(output_dir, "single-weeks-by-log-range"))
 
     if not label_files:
         # create additional stats using date ranges found in the log itself

--- a/sleep_analysis/log_parser.py
+++ b/sleep_analysis/log_parser.py
@@ -1,6 +1,8 @@
 import datetime
 import math
 import re
+import os
+import csv
 from typing import Dict, List
 
 import pandas as pd
@@ -387,4 +389,79 @@ def compute_overall_stats(weekly_stats: Dict[str, pd.DataFrame]) -> pd.DataFrame
                 overall[f'{base}_median'] = med_t.strftime('%I:%M%p').lower()
 
     return pd.DataFrame([overall])
+
+
+
+def _format_range(start: datetime.date, end: datetime.date) -> str:
+    """Return date range label like '2025--01-01--01-07'."""
+    return f"{start.year:04d}--{start:%m-%d}--{end:%m-%d}"
+
+
+def _format_raw_value(value: str) -> str:
+    """Format ``value`` for CSV output, normalizing times when possible."""
+    if value is None:
+        return ''
+    value = value.strip()
+    if '|' not in value and value.lower().endswith(('am', 'pm')):
+        t = _parse_time(value)
+        if t is not None:
+            return datetime.datetime.combine(datetime.date(1900, 1, 1), t).strftime('%-I:%M %p')
+    return value
+
+
+def export_single_weeks_csv(logfile: str, output_dir: str) -> None:
+    """Write per-week CSVs of raw log values extracted from ``logfile``."""
+    with open(logfile, 'r', encoding='utf-8') as f:
+        lines = f.readlines()
+
+    week_label = None
+    week_days: List[datetime.date] = []
+    week_data: Dict[str, List[str]] = {}
+
+    for raw_line in lines:
+        line = raw_line.rstrip('\n')
+        if not line.strip() or line.strip().startswith('...'):
+            continue
+
+        expanded = line.replace('\t', '    ')
+        indent = len(expanded) - len(expanded.lstrip(' '))
+        stripped = line.strip()
+
+        if _WEEK_HEADER_RE.match(stripped):
+            if week_label and week_days:
+                _write_week_csv(output_dir, week_days, week_data)
+                week_data = {}
+            res = _parse_week_header(stripped)
+            if res:
+                week_label, week_days = res
+            else:
+                week_label = None
+                week_days = []
+        elif indent >= 4 and week_label:
+            if '?' in stripped:
+                q_part, values_part = stripped.split('?', 1)
+                question = (q_part + '?').strip()
+                values = values_part.strip().split()
+                week_data[question] = values
+
+    if week_label and week_days:
+        _write_week_csv(output_dir, week_days, week_data)
+
+
+def _write_week_csv(output_dir: str, days: List[datetime.date], data: Dict[str, List[str]]) -> None:
+    os.makedirs(output_dir, exist_ok=True)
+    start = days[0]
+    end = days[-1]
+    label = _format_range(start, end)
+    path = os.path.join(output_dir, f'data-{label}.csv')
+    header = [''] + [f'{d.month}/{d.day}' for d in days]
+    with open(path, 'w', encoding='utf-8', newline='') as f:
+        writer = csv.writer(f, lineterminator='\n')
+        writer.writerow(header)
+        for question, values in data.items():
+            row = [question]
+            for i in range(len(days)):
+                val = values[i] if i < len(values) else ''
+                row.append(_format_raw_value(val))
+            writer.writerow(row)
 

--- a/tests/input/log-pivot.txt
+++ b/tests/input/log-pivot.txt
@@ -1,0 +1,61 @@
+    Thu6/19-Wed25
+
+        1b. What time start winding down? 2:20am 2:50am 2:10am 2:10am 2:20am 3:20am 3:40am
+
+        1.2b. What time did you get into bed & commit to sleep? 3:34am 4:22am 3:33am 4:13am 4:02am 4:25am 4:25am
+
+        1.3b. Wind-down activities (if not reading book)
+
+            Day 1, Jun19: Relaxing viewing, relaxing game
+
+            Day 2: relaxing game
+
+            Day 3: relaxing game
+
+        2. How long do you estimate it took to fall asleep (minutes)? 25 50 12 25 15 35 13
+
+            Day2, Jun20: Strange GERD episode; 2nd time this has ever happened. Meds did nothing. Was sitting up straight. No food for 4-5 hours. No spicy. 1 drink 8 hours prior.
+
+        ...
+
+        3. How many times did you wake up during the night? 0 0 0 0 1 0 0
+
+            (Not counting your final wake up for the day)
+
+        4. In total, how long did these awakenings last (minutes)? . . . . 1 . .
+
+        5. When awake during the night, how long did you spend out of bed (minutes)? . . . . . . .
+
+        ...
+
+        6. What time did you wake up? 11:30am 11:30am 11:30am 11:30am 11:30am 11:30am 11:30am
+
+            (Final wake up of morning)
+
+        7. What time did you get out of bed? 11:45am 12:35pm 11:40am 12:01pm 11:43am 11:57am 11:40am
+
+            Day 2, Jun20: Probably will need to switch to physical alarms. Ashley is helpful, but on some days like today, I was extraordinarily tired. I don't know why. She didn't stay for more than a second though, and didn't turn on the light until later. The worst thing was probably letting in my cat, which slipped under the covers to sleep against me, which is just about impossible for me to resist.
+
+        8. In TOTAL, how many hours of sleep did you get? 7:31 6:18 7:45 6:52 7:12 6:30 6:52
+
+        9. In TOTAL, how many hours did you spend in bed? 8:11 8:13 8:07 7:48 7:41 7:32 7:15
+
+        ...
+
+        10. Quality of your sleep (1-10)? 10 10 10 10 9 10 10
+
+        11. Did you take naps during the day? 0 0 0 0 0 0 0
+
+        12. Mood during the day (1-10)? 9 6 7 7 8.5 7 9
+
+        13. Fatigue level during the day (1-10)? 0 5 3.5 3 2 3 1
+
+        ...
+
+        14. If alcohol, how many standard drinks? 0 1.3 0 2 3 0 0
+
+        15. - what type? . beer5%16oz . beer5.6%12oz|beer4.6%12oz mixed5%12oz|mixed5%12oz|beer5%12oz . .
+
+        16. - what time? . 7:30am . 12:40am|1:18am 10:30pm|11:42pm|12:50pm
+
+        17. Second wind? . . . 5pm . 10:30pm .

--- a/tests/output_expected/data-2025--06-19--06-25.csv
+++ b/tests/output_expected/data-2025--06-19--06-25.csv
@@ -1,0 +1,19 @@
+,6/19,6/20,6/21,6/22,6/23,6/24,6/25
+1b. What time start winding down?,2:20 AM,2:50 AM,2:10 AM,2:10 AM,2:20 AM,3:20 AM,3:40 AM
+1.2b. What time did you get into bed & commit to sleep?,3:34 AM,4:22 AM,3:33 AM,4:13 AM,4:02 AM,4:25 AM,4:25 AM
+2. How long do you estimate it took to fall asleep (minutes)?,25,50,12,25,15,35,13
+3. How many times did you wake up during the night?,0,0,0,0,1,0,0
+"4. In total, how long did these awakenings last (minutes)?",.,.,.,.,1,.,.
+"5. When awake during the night, how long did you spend out of bed (minutes)?",.,.,.,.,.,.,.
+6. What time did you wake up?,11:30 AM,11:30 AM,11:30 AM,11:30 AM,11:30 AM,11:30 AM,11:30 AM
+7. What time did you get out of bed?,11:45 AM,12:35 PM,11:40 AM,12:01 PM,11:43 AM,11:57 AM,11:40 AM
+"8. In TOTAL, how many hours of sleep did you get?",7:31,6:18,7:45,6:52,7:12,6:30,6:52
+"9. In TOTAL, how many hours did you spend in bed?",8:11,8:13,8:07,7:48,7:41,7:32,7:15
+10. Quality of your sleep (1-10)?,10,10,10,10,9,10,10
+11. Did you take naps during the day?,0,0,0,0,0,0,0
+12. Mood during the day (1-10)?,9,6,7,7,8.5,7,9
+13. Fatigue level during the day (1-10)?,0,5,3.5,3,2,3,1
+"14. If alcohol, how many standard drinks?",0,1.3,0,2,3,0,0
+15. - what type?,.,beer5%16oz,.,beer5.6%12oz|beer4.6%12oz,mixed5%12oz|mixed5%12oz|beer5%12oz,.,.
+16. - what time?,.,7:30 AM,.,12:40am|1:18am,10:30pm|11:42pm|12:50pm,,
+17. Second wind?,.,.,.,5:00 PM,.,10:30 PM,.

--- a/tests/test_export_single_weeks.py
+++ b/tests/test_export_single_weeks.py
@@ -1,0 +1,14 @@
+import os
+import filecmp
+
+from sleep_analysis.log_parser import export_single_weeks_csv
+
+
+def test_export_single_weeks_csv(tmp_path):
+    log_path = 'tests/input/log-pivot.txt'
+    out_dir = tmp_path
+    export_single_weeks_csv(log_path, out_dir)
+    expected = 'tests/output_expected/data-2025--06-19--06-25.csv'
+    out_file = os.path.join(out_dir, 'data-2025--06-19--06-25.csv')
+    assert os.path.exists(out_file)
+    assert filecmp.cmp(out_file, expected, shallow=False)


### PR DESCRIPTION
## Summary
- support exporting raw data CSV per log week
- parse log data for export with time normalization
- run export for each logfile in `run_analysis`
- test CSV export

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68708c61c314832c8f194682ce8b1510