### PR TITLE
Add annotation markdown export

### DIFF
--- a/tests/input/log-annotations-week.txt
+++ b/tests/input/log-annotations-week.txt
@@ -1,0 +1,58 @@
+Thu6/19-Wed25
+
+    1b. What time start winding down? 2:20am 2:50am 2:10am 2:10am 2:20am 3:20am 3:40am
+
+    1.2b. What time did you get into bed & commit to sleep? 3:34am 4:22am 3:33am 4:13am 4:02am 4:25am 4:25am
+
+    1.3b. Wind-down activities (if not reading book)
+
+        Day 1, Jun19: Relaxing viewing, relaxing game
+        I had a couple days of reading this week. I should have read more. I also did a night of TV. But I didn't track what days.
+
+    2. How long do you estimate it took to fall asleep (minutes)? 25 50 12 25 15 35 13
+
+        Day2, Jun20: Strange GERD episode; 2nd time this has ever happened. Meds did nothing. Was sitting up straight. No food for 4-5 hours. No spicy. 1 drink 8 hours prior.
+
+    ...
+
+    3. How many times did you wake up during the night? 0 0 0 0 1 0 0
+
+    4. In total, how long did these awakenings last (minutes)? . . . . 1 . .
+
+    5. When awake during the night, how long did you spend out of bed (minutes)? . . . . . . .
+
+    ...
+
+    6. What time did you wake up? 11:30am 11:30am 11:30am 11:30am 11:30am 11:30am 11:30am
+
+    7. What time did you get out of bed? 11:45am 12:35pm 11:40am 12:01pm 11:43am 11:57am 11:40am
+
+        Day 2, Jun20: Probably will need to switch to physical alarms (edit: Actually after writing this, she's been waking me up consistently at the right time!). Ashley is helpful, but on some days like today, I was extraordinarily tired. I don't know why. She didn't stay for more than a second though, and didn't turn on the light until later. The worst thing was probably letting in my cat, which slipped under the covers to sleep against me, which is just about impossible for me to resist.
+
+    8. In TOTAL, how many hours of sleep did you get? 7:31 6:18 7:45 6:52 7:12 6:30 6:52
+
+    9. In TOTAL, how many hours did you spend in bed? 8:11 8:13 8:07 7:48 7:41 7:32 7:15
+
+    ...
+
+    10. Quality of your sleep (1-10)? 10 10 10 10 9 10 10
+
+    11. Did you take naps during the day? 0 0 0 0 0 0 0
+
+    12. Mood during the day (1-10)? 9 6 7 7 8.5 7 9
+
+    13. Fatigue level during the day (1-10)? 0 5 3.5 3 2 3 1
+
+    ...
+
+    14. If alcohol, how many standard drinks? 0 1.3 0 2 3 0 0
+
+    15. - what type? . beer5%16oz . beer5.6%12oz|beer4.6%12oz mixed5%12oz|mixed5%12oz|beer5%12oz . .
+
+    16. - what time? . 7:30am . 12:40am|1:18am 10:30pm|11:42pm|12:50pm 
+
+    17. Second wind? . . . 5pm . 10:30pm .
+
+        Day 4, Jun22: Normally I think of "second wind" as something that happens late at night, but I realize that there is a sense in which this can happen multiple times a day. For example, today, I was very tired from when I woke up, until almost 5pm (5.5 hours after waking up). But then it started to get better. This decrease in sleepiness lasted mostly right up until bed time. I should one that up until and for 1 hour after 5pm, I had a fair amount of caffeine (later than I typically do), but also engaged in hours of active, cognitively demanding work with little break. Maybe that is the cause.
+
+        Day 6, June 24th: strange I seem to have kind of multiple second winds. I had much more energy than usual when I woke up, but I crashed a few hours later. Usually it's the opposite. And then a few hours after that I had a second wind. Then my cats started to snuggle with me and I got tired again. Then I had a second wind at 11:00 p.m. again.

--- a/tests/output_expected/annotations-2025--06-19--06-25.md
+++ b/tests/output_expected/annotations-2025--06-19--06-25.md
@@ -1,0 +1,13 @@
+**1.3b. Wind-down activities (if not reading book)**
+_Day 1, Jun19_: Relaxing viewing, relaxing game
+I had a couple days of reading this week. I should have read more. I also did a night of TV. But I didn't track what days.
+
+**2. How long do you estimate it took to fall asleep (minutes)?**
+_Day2, Jun20_: Strange GERD episode; 2nd time this has ever happened. Meds did nothing. Was sitting up straight. No food for 4-5 hours. No spicy. 1 drink 8 hours prior.
+
+**7. What time did you get out of bed?**
+_Day 2, Jun20_: Probably will need to switch to physical alarms (edit: Actually after writing this, she's been waking me up consistently at the right time!). Ashley is helpful, but on some days like today, I was extraordinarily tired. I don't know why. She didn't stay for more than a second though, and didn't turn on the light until later. The worst thing was probably letting in my cat, which slipped under the covers to sleep against me, which is just about impossible for me to resist.
+
+**17. Second wind?**
+_Day 4, Jun22_: Normally I think of "second wind" as something that happens late at night, but I realize that there is a sense in which this can happen multiple times a day. For example, today, I was very tired from when I woke up, until almost 5pm (5.5 hours after waking up). But then it started to get better. This decrease in sleepiness lasted mostly right up until bed time. I should one that up until and for 1 hour after 5pm, I had a fair amount of caffeine (later than I typically do), but also engaged in hours of active, cognitively demanding work with little break. Maybe that is the cause.
+_Day 6, June 24th_: strange I seem to have kind of multiple second winds. I had much more energy than usual when I woke up, but I crashed a few hours later. Usually it's the opposite. And then a few hours after that I had a second wind. Then my cats started to snuggle with me and I got tired again. Then I had a second wind at 11:00 p.m. again.

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -1,5 +1,4 @@
 import os
-import filecmp
 import sys
 
 ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
@@ -11,11 +10,12 @@ import tests.test_log_parser  # ensure pandas stub is available
 from sleep_analysis.log_parser import export_single_weeks_csv
 
 
-def test_export_single_weeks_csv(tmp_path):
-    log_path = 'tests/input/log-pivot.txt'
+def test_save_week_log_annotations(tmp_path):
+    log_path = 'tests/input/log-annotations-week.txt'
     out_dir = tmp_path
     export_single_weeks_csv(log_path, out_dir)
-    expected = 'tests/output_expected/data-2025--06-19--06-25.csv'
-    out_file = os.path.join(out_dir, 'data-2025--06-19--06-25.csv')
+    expected = 'tests/output_expected/annotations-2025--06-19--06-25.md'
+    out_file = os.path.join(out_dir, 'annotations-2025--06-19--06-25.md')
     assert os.path.exists(out_file)
-    assert filecmp.cmp(out_file, expected, shallow=False)
+    with open(out_file) as f, open(expected) as g:
+        assert f.read() == g.read()


### PR DESCRIPTION
## Summary
- extract per-week log snippets and generate annotations markdown
- export annotations in `_write_week_csv`
- update tests to exercise markdown export
- add fixture files for annotation test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68709db8f4a8832ca84b1476ffb57c94