### PR TITLE
Fix CRLF mismatch in export test

### DIFF
--- a/tests/test_export_single_weeks.py
+++ b/tests/test_export_single_weeks.py
@@ -1,5 +1,4 @@
 import os
-import filecmp
 import sys
 
 ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
@@ -18,4 +17,7 @@ def test_export_single_weeks_csv(tmp_path):
     expected = 'tests/output_expected/data-with-questions-2025--06-19--06-25.csv'
     out_file = os.path.join(out_dir, 'data-with-questions-2025--06-19--06-25.csv')
     assert os.path.exists(out_file)
-    assert filecmp.cmp(out_file, expected, shallow=False)
+    with open(out_file, 'r', encoding='utf-8') as f_out, open(expected, 'r', encoding='utf-8') as f_exp:
+        out_text = f_out.read().replace('\r\n', '\n')
+        exp_text = f_exp.read().replace('\r\n', '\n')
+    assert out_text == exp_text


### PR DESCRIPTION
## Summary
- update `test_export_single_weeks_csv` to normalize newlines

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870b538e220832c9a50b8705997d2f9