### PR TITLE
Fix pandas concat warnings

### DIFF
--- a/sleep_analysis/__main__.py
+++ b/sleep_analysis/__main__.py
@@ -13,6 +13,7 @@ from sleep_analysis.log_parser import (
     export_weeks_from_dataframe,
     export_questions_table,
     _prepare_stats_for_output,
+    _filter_non_empty_frames,
 )
 
 
@@ -86,15 +87,7 @@ def run_analysis(logfile: str, output_dir: str, label_files: bool = False) -> No
             log_rows.append(out_df)
 
         if log_rows:
-            # Filter out completely empty dataframes to avoid concat warnings
-            valid_rows: list[pd.DataFrame] = []
-            for r in log_rows:
-                try:
-                    empty_df = r.dropna(how='all').empty
-                except Exception:
-                    empty_df = r.empty or all(all(val is None for val in r[col]) for col in r.columns)
-                if not empty_df:
-                    valid_rows.append(r)
+            valid_rows = _filter_non_empty_frames(log_rows)
 
             if valid_rows:
                 by_log_df: pd.DataFrame = pd.concat(valid_rows, ignore_index=True)

--- a/sleep_analysis/log_parser.py
+++ b/sleep_analysis/log_parser.py
@@ -3,7 +3,7 @@ import math
 import re
 import os
 import csv
-from typing import Dict, List
+from typing import Dict, List, Iterable
 
 import pandas as pd
 
@@ -452,20 +452,29 @@ def compute_weekly_stats(df: pd.DataFrame) -> Dict[str, pd.DataFrame]:
     return weekly_dfs
 
 
+def _filter_non_empty_frames(frames: Iterable[pd.DataFrame]) -> list[pd.DataFrame]:
+    """Return frames that are not completely empty or all ``NaN``."""
+
+    valid: list[pd.DataFrame] = []
+    for df in frames:
+        try:
+            empty_df = df.dropna(how="all").empty
+        except Exception:
+            empty_df = df.empty or all(
+                all(val is None for val in df[col]) for col in df.columns
+            )
+        if not empty_df:
+            valid.append(df)
+    return valid
+
+
 def compute_overall_stats(weekly_stats: Dict[str, pd.DataFrame]) -> pd.DataFrame:
     """Aggregate ``weekly_stats`` into a single overall statistics dataframe."""
 
     if not weekly_stats:
         return pd.DataFrame()
 
-    valid_stats = []
-    for df in weekly_stats.values():
-        try:
-            empty_df = df.dropna(how="all").empty
-        except Exception:
-            empty_df = df.empty or all(all(val is None for val in df[col]) for col in df.columns)
-        if not empty_df:
-            valid_stats.append(df)
+    valid_stats = _filter_non_empty_frames(weekly_stats.values())
 
     if not valid_stats:
         return pd.DataFrame()


### PR DESCRIPTION
## Summary
- filter out empty weekly stats before concatenation
- skip empty log rows when aggregating log date ranges

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870b6e94e8c832cb96f923d76e9cf58